### PR TITLE
Add folders command

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,46 @@ file
   .description('delete file')
   .action(cmd('file'))
 
+const folders = program
+  .command('folders')
+  .description('folder commands')
+folders
+  .command('get <folderId>')
+  .description('get folder information')
+  .action(cmd('folders'))
+folders
+  .command('get-items <folderId>')
+  .description('get items in a folder')
+  .option('-l, --limit <limit>', 'maximum number of items to return')
+  .action(cmd('folders'))
+folders
+  .command('create <name>')
+  .description('create a new folder')
+  .option('-p, --parent-id <parentId>', 'parent folder id')
+  .action(cmd('folders'))
+folders
+  .command('update <folderId>')
+  .description('update folder information')
+  .option('-n, --name <name>', 'new name for the folder')
+  .option('-d, --description <description>', 'new description for the folder')
+  .action(cmd('folders'))
+folders
+  .command('delete <folderId>')
+  .description('delete a folder')
+  .option('-r, --recursive <recursive>', 'delete folder recursively', true)
+  .action(cmd('folders'))
+folders
+  .command('copy <folderId>')
+  .description('copy a folder')
+  .option('-d, --dest-folder-id <destFolderId>', 'destination folder id')
+  .option('-n, --name <name>', 'new name for the copied folder')
+  .action(cmd('folders'))
+folders
+  .command('move <folderId>')
+  .description('move a folder')
+  .option('-d, --dest-folder-id <destFolderId>', 'destination folder id')
+  .action(cmd('folders'))
+
 const groups = program
   .command('groups')
   .description('groups commands')

--- a/src/folders.js
+++ b/src/folders.js
@@ -1,0 +1,66 @@
+const camelize = require('./lib/camelize')
+const client = require('./lib/client')
+const handleError = require('./lib/handle-error')
+const log = require('./lib/logger')
+
+const operations = {
+  get: async (folderId) => {
+    const folder = await client.folders.get(folderId)
+    log(folder)
+    return folder
+  },
+  getItems: async (folderId, { limit = 100 } = {}) => {
+    const items = await client.folders.getItems(folderId, { limit })
+    log(items)
+    return items
+  },
+  create: async (name, options) => {
+    const parentId = options['parent-id'] || '0'
+    const folder = await client.folders.create(parentId, name)
+    log(folder)
+    return folder
+  },
+  update: async (folderId, options) => {
+    const updates = {}
+    if (options.name) updates.name = options.name
+    if (options.description) updates.description = options.description
+    
+    const folder = await client.folders.update(folderId, updates)
+    log(folder)
+    return folder
+  },
+  delete: async (folderId, { recursive = true } = {}) => {
+    await client.folders.delete(folderId, { recursive })
+    log('Folder deleted!')
+    return 'Folder deleted!'
+  },
+  copy: async (folderId, options) => {
+    const destFolderId = options['dest-folder-id'] || '0'
+    const copyOptions = {}
+    if (options.name) copyOptions.name = options.name
+    
+    const folder = await client.folders.copy(folderId, destFolderId, copyOptions)
+    log(folder)
+    return folder
+  },
+  move: async (folderId, options) => {
+    const destFolderId = options['dest-folder-id'] || '0'
+    const folder = await client.folders.move(folderId, destFolderId)
+    log(folder)
+    return folder
+  }
+}
+
+async function folders (arg, options, subCommand) {
+  try {
+    const name = subCommand ? subCommand._name : options._name
+    const operation = operations[camelize(name)]
+    const result = await operation(arg, options)
+
+    return result
+  } catch (err) {
+    handleError(err)
+  }
+}
+
+module.exports = folders

--- a/test/folders.test.js
+++ b/test/folders.test.js
@@ -1,0 +1,60 @@
+const folders = require('../src/folders')
+
+let id
+
+test('can create a folder', async () => {
+  const result = await folders('Test Folder', { 'parent-id': '0' }, { _name: 'create' })
+  id = result.id
+  
+  expect(result.name).toBe('Test Folder')
+})
+
+test('can get a folder', async () => {
+  const result = await folders(id, {}, { _name: 'get' })
+  
+  expect(result.id).toBe(id)
+  expect(result.name).toBe('Test Folder')
+})
+
+test('can get folder items', async () => {
+  const result = await folders(id, { limit: 100 }, { _name: 'getItems' })
+  
+  expect(result.entries).toBeDefined()
+})
+
+test('can update a folder', async () => {
+  const result = await folders(id, { name: 'Updated Test Folder' }, { _name: 'update' })
+  
+  expect(result.name).toBe('Updated Test Folder')
+})
+
+test('can copy a folder', async () => {
+  const result = await folders(id, { 'dest-folder-id': '0', name: 'Copied Test Folder' }, { _name: 'copy' })
+  
+  expect(result.name).toBe('Copied Test Folder')
+  
+  // Clean up the copied folder
+  await folders(result.id, {}, { _name: 'delete' })
+})
+
+test('can move a folder', async () => {
+  // First create a temporary folder to move into
+  const tempFolder = await folders('Temp Folder', { 'parent-id': '0' }, { _name: 'create' })
+  
+  // Move our test folder into the temp folder
+  const result = await folders(id, { 'dest-folder-id': tempFolder.id }, { _name: 'move' })
+  
+  expect(result.parent.id).toBe(tempFolder.id)
+  
+  // Move it back to root for cleanup
+  await folders(id, { 'dest-folder-id': '0' }, { _name: 'move' })
+  
+  // Clean up the temp folder
+  await folders(tempFolder.id, {}, { _name: 'delete' })
+})
+
+test('can delete a folder', async () => {
+  const result = await folders(id, {}, { _name: 'delete' })
+  
+  expect(result).toBe('Folder deleted!')
+})


### PR DESCRIPTION
This PR adds a new `folders` command to the CLI with the following subcommands:

- `get <folderId>` - Get folder information
- `get-items <folderId>` - Get items in a folder
- `create <name>` - Create a new folder
- `update <folderId>` - Update folder information
- `delete <folderId>` - Delete a folder
- `copy <folderId>` - Copy a folder
- `move <folderId>` - Move a folder

Includes tests for all operations.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author