### PR TITLE
Add folder commands to CLI

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,47 @@ file
   .description('delete file')
   .action(cmd('file'))
 
+const folder = program
+  .command('folder')
+  .description('folder commands')
+folder
+  .command('get <folderId>')
+  .description('get folder')
+  .action(cmd('folder'))
+folder
+  .command('get-items <folderId>')
+  .description('get folder items')
+  .option('-l, --limit <limit>', 'limit of items to return')
+  .option('-o, --offset <offset>', 'offset of items to return')
+  .action(cmd('folder'))
+folder
+  .command('create <name>')
+  .description('create folder')
+  .option('-p, --parent-id <parentId>', 'parent folder id')
+  .action(cmd('folder'))
+folder
+  .command('update <folderId>')
+  .description('update folder')
+  .option('-n, --name <name>', 'name of folder')
+  .option('-d, --description <description>', 'description of folder')
+  .action(cmd('folder'))
+folder
+  .command('delete <folderId>')
+  .description('delete folder')
+  .option('-r, --recursive', 'delete folder recursively')
+  .action(cmd('folder'))
+folder
+  .command('copy <folderId>')
+  .description('copy folder')
+  .option('-d, --dest-folder-id <destFolderId>', 'destination folder id')
+  .option('-n, --name <name>', 'name of folder')
+  .action(cmd('folder'))
+folder
+  .command('move <folderId>')
+  .description('move folder')
+  .option('-d, --dest-folder-id <destFolderId>', 'destination folder id')
+  .action(cmd('folder'))
+
 const groups = program
   .command('groups')
   .description('groups commands')

--- a/src/folder.js
+++ b/src/folder.js
@@ -1,0 +1,63 @@
+const camelize = require('./lib/camelize')
+const client = require('./lib/client')
+const handleError = require('./lib/handle-error')
+const log = require('./lib/logger')
+
+const operations = {
+  get: async (folderId) => {
+    const folder = await client.folders.get(folderId)
+    log(folder)
+    return folder
+  },
+  getItems: async (folderId, { limit = 100, offset = 0 }) => {
+    const items = await client.folders.getItems(folderId, { limit, offset })
+    log(items)
+    return items
+  },
+  create: async (name, { parentId = '0' }) => {
+    const folder = await client.folders.create(parentId, name)
+    log(folder)
+    return folder
+  },
+  update: async (folderId, { name, description }) => {
+    const updates = {}
+    if (name) updates.name = name
+    if (description) updates.description = description
+    
+    const folder = await client.folders.update(folderId, updates)
+    log(folder)
+    return folder
+  },
+  delete: async (folderId, { recursive = false } = {}) => {
+    await client.folders.delete(folderId, { recursive })
+    log('Folder deleted!')
+    return 'Folder deleted!'
+  },
+  copy: async (folderId, { destFolderId, name }) => {
+    const options = {}
+    if (name) options.name = name
+    
+    const folder = await client.folders.copy(folderId, destFolderId, options)
+    log(folder)
+    return folder
+  },
+  move: async (folderId, { destFolderId }) => {
+    const folder = await client.folders.move(folderId, destFolderId)
+    log(folder)
+    return folder
+  }
+}
+
+async function folder(arg, options, subCommand) {
+  try {
+    const name = subCommand ? subCommand._name : options._name
+    const operation = operations[camelize(name)]
+    const result = await operation(arg, options)
+
+    return result
+  } catch (err) {
+    handleError(err)
+  }
+}
+
+module.exports = folder

--- a/test/folder.test.js
+++ b/test/folder.test.js
@@ -1,0 +1,63 @@
+const folder = require('../src/folder')
+const fs = require('fs')
+const path = require('path')
+
+let id
+
+test('can create a folder', async () => {
+  const folderName = 'Test Folder ' + Date.now()
+  const result = await folder(folderName, { parentId: '0' }, { _name: 'create' })
+  id = result.id
+  
+  expect(result.name).toBe(folderName)
+})
+
+test('can get a folder', async () => {
+  const result = await folder(id, {}, { _name: 'get' })
+  
+  expect(result.id).toBe(id)
+})
+
+test('can get folder items', async () => {
+  const result = await folder(id, { limit: 100, offset: 0 }, { _name: 'getItems' })
+  
+  expect(result.entries).toBeDefined()
+})
+
+test('can update a folder', async () => {
+  const newName = 'Updated Test Folder ' + Date.now()
+  const result = await folder(id, { name: newName }, { _name: 'update' })
+  
+  expect(result.name).toBe(newName)
+})
+
+test('can copy a folder', async () => {
+  const result = await folder(id, { destFolderId: '0' }, { _name: 'copy' })
+  
+  expect(result.parent.id).toBe('0')
+  
+  // Clean up the copied folder
+  await folder(result.id, { recursive: true }, { _name: 'delete' })
+})
+
+test('can move a folder', async () => {
+  // Create a temporary folder to move into
+  const tempFolder = await folder('Temp Folder ' + Date.now(), { parentId: '0' }, { _name: 'create' })
+  
+  // Move our test folder into the temp folder
+  const result = await folder(id, { destFolderId: tempFolder.id }, { _name: 'move' })
+  
+  expect(result.parent.id).toBe(tempFolder.id)
+  
+  // Move it back to root
+  await folder(id, { destFolderId: '0' }, { _name: 'move' })
+  
+  // Clean up the temp folder
+  await folder(tempFolder.id, { recursive: true }, { _name: 'delete' })
+})
+
+test('can delete a folder', async () => {
+  const result = await folder(id, { recursive: true }, { _name: 'delete' })
+  
+  expect(result).toBe('Folder deleted!')
+})


### PR DESCRIPTION
This PR adds folder commands to the Box CLI, including:

- Get folder information
- Get folder items
- Create folder
- Update folder
- Delete folder
- Copy folder
- Move folder

Tests are also included but require proper Box API setup to run.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author