### PR TITLE
Add folder commands to CLI

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,34 @@ file
   .description('delete file')
   .action(cmd('file'))
 
+const folders = program
+  .command('folders')
+  .description('folder commands')
+folders
+  .command('get <folderId>')
+  .description('get folder information')
+  .action(cmd('folders'))
+folders
+  .command('create <name>')
+  .description('create a new folder')
+  .option('-p, --parent-id <parentId>', 'parent folder id')
+  .action(cmd('folders'))
+folders
+  .command('update <folderId>')
+  .description('update folder information')
+  .option('-n, --name <name>', 'new folder name')
+  .option('-d, --description <description>', 'folder description')
+  .action(cmd('folders'))
+folders
+  .command('delete <folderId>')
+  .description('delete folder')
+  .action(cmd('folders'))
+folders
+  .command('list <folderId>')
+  .description('list items in folder')
+  .option('-l, --limit <limit>', 'maximum number of items to return')
+  .action(cmd('folders'))
+
 const groups = program
   .command('groups')
   .description('groups commands')

--- a/src/folders.js
+++ b/src/folders.js
@@ -1,0 +1,46 @@
+const client = require('./lib/client')
+const log = require('./lib/logger')
+
+const operations = {
+  get: async (folderId) => {
+    const folder = await client.folders.get(folderId)
+    log(folder)
+    return folder
+  },
+  create: async (name, { parentId }) => {
+    const folder = await client.folders.create(parentId, name)
+    log(folder)
+    return folder
+  },
+  update: async (folderId, { name, description }) => {
+    const updates = {}
+    if (name) updates.name = name
+    if (description) updates.description = description
+    
+    const folder = await client.folders.update(folderId, updates)
+    log(folder)
+    return folder
+  },
+  delete: async (folderId) => {
+    await client.folders.delete(folderId)
+    log('Folder deleted!')
+    return 'Folder deleted!'
+  },
+  list: async (folderId, { limit }) => {
+    const options = {}
+    if (limit) options.limit = limit
+    
+    const items = await client.folders.getItems(folderId, options)
+    log(items)
+    return items
+  }
+}
+
+async function folders(arg, options, subCommand) {
+  const operation = operations[subCommand._name]
+  const result = await operation(arg, options)
+
+  return result
+}
+
+module.exports = folders

--- a/test/folders.test.js
+++ b/test/folders.test.js
@@ -1,0 +1,39 @@
+const folders = require('../src/folders')
+
+let id
+
+test('can create a folder', async () => {
+  const result = await folders('Test Folder', { parentId: '0' }, { _name: 'create' })
+  id = result.id
+  
+  expect(result.name).toBe('Test Folder')
+  expect(result.parent.id).toBe('0')
+})
+
+test('can get a folder', async () => {
+  const result = await folders(id, {}, { _name: 'get' })
+  
+  expect(result.id).toBe(id)
+  expect(result.name).toBe('Test Folder')
+})
+
+test('can update a folder', async () => {
+  const result = await folders(id, { name: 'Updated Folder', description: 'Test description' }, { _name: 'update' })
+  
+  expect(result.id).toBe(id)
+  expect(result.name).toBe('Updated Folder')
+  expect(result.description).toBe('Test description')
+})
+
+test('can list folder items', async () => {
+  const result = await folders(id, { limit: 100 }, { _name: 'list' })
+  
+  expect(result.entries).toBeDefined()
+  expect(Array.isArray(result.entries)).toBe(true)
+})
+
+test('can delete a folder', async () => {
+  const result = await folders(id, {}, { _name: 'delete' })
+  
+  expect(result).toBe('Folder deleted!')
+})


### PR DESCRIPTION
This PR adds folder commands to the Box CLI, including:

- Get folder information
- Create a new folder
- Update folder information
- Delete a folder
- List items in a folder

Tests are included for all operations.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author