### PR TITLE
add folders commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,29 @@ file
   .description('delete file')
   .action(cmd('file'))
 
+const folders = program
+  .command('folders')
+  .description('folder commands')
+folders
+  .command('get <folderId>')
+  .description('get folder information')
+  .action(cmd('folders'))
+folders
+  .command('create <name>')
+  .description('create folder')
+  .option('-p, --parent <parentId>', 'parent folder id')
+  .action(cmd('folders'))
+folders
+  .command('update <folderId>')
+  .description('update folder')
+  .option('-n, --name <name>', 'new folder name')
+  .option('-d, --description <description>', 'folder description')
+  .action(cmd('folders'))
+folders
+  .command('delete <folderId>')
+  .description('delete folder')
+  .action(cmd('folders'))
+
 const groups = program
   .command('groups')
   .description('groups commands')

--- a/src/folders.js
+++ b/src/folders.js
@@ -1,0 +1,34 @@
+const client = require('./lib/client')
+const log = require('./lib/logger')
+
+const operations = {
+  get: async (folderId) => {
+    const folder = await client.folders.get(folderId)
+    log(folder)
+    return folder
+  },
+  create: async (name, { parentID }) => {
+    const folder = await client.folders.create(parentID, name)
+    log(folder)
+    return folder
+  },
+  update: async (folderId, { name, description }) => {
+    const folder = await client.folders.update(folderId, { name, description })
+    log(folder)
+    return folder
+  },
+  delete: async (folderId) => {
+    await client.folders.delete(folderId)
+    log('Folder deleted')
+    return 'Folder deleted'
+  }
+}
+
+async function folders (arg, options, subCommand) {
+  const operation = operations[subCommand._name]
+  const result = await operation(arg, options)
+
+  return result
+}
+
+module.exports = folders

--- a/test/folders.test.js
+++ b/test/folders.test.js
@@ -1,0 +1,53 @@
+const folders = require('../src/folders')
+
+let folderId
+
+describe('Folder operations', () => {
+  test('can create a folder', async () => {
+    const folderName = 'Test Folder'
+    // Create in root folder (parentID '0')
+    const result = await folders(folderName, { parentID: '0' }, { _name: 'create' })
+    expect(result.name).toBe(folderName)
+    expect(result.id).toBeDefined()
+    folderId = result.id
+  })
+
+  test('can get a folder', async () => {
+    // This test depends on the previous test creating a folder
+    expect(folderId).toBeDefined() // Ensure folderId was set
+    const result = await folders(folderId, {}, { _name: 'get' })
+    expect(result.id).toBe(folderId)
+    expect(result.name).toBe('Test Folder')
+  })
+
+  test('can update a folder', async () => {
+    // This test depends on the previous test creating a folder
+    expect(folderId).toBeDefined() // Ensure folderId was set
+    const newName = 'Updated Test Folder'
+    const newDescription = 'This is an updated description.'
+    const result = await folders(folderId, { name: newName, description: newDescription }, { _name: 'update' })
+    expect(result.id).toBe(folderId)
+    expect(result.name).toBe(newName)
+    expect(result.description).toBe(newDescription)
+  })
+
+  test('can delete a folder', async () => {
+    // This test depends on the previous tests
+    expect(folderId).toBeDefined() // Ensure folderId was set
+    const result = await folders(folderId, {}, { _name: 'delete' })
+    expect(result).toBe('Folder deleted')
+
+    // Optionally, try to get the folder again to ensure it's gone
+    try {
+      await folders(folderId, {}, { _name: 'get' })
+    } catch (error) {
+      // Expect an error when trying to get a deleted folder
+      // The Box SDK might throw an error with a specific status code for "not found"
+      // For example, if it's a 404:
+      // expect(error.statusCode).toBe(404);
+      // Or check for a specific error message if the SDK provides one
+      expect(error).toBeDefined()
+    }
+  })
+})
+


### PR DESCRIPTION
Add a folders command to get, create, update and delete folders within a box account.

Includes tests.

Solves BOX-1 and BOX-3 jira tickets.