### PR TITLE
Add folders command to CLI

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,12 +133,12 @@ enterprise
   .description('invite user to enterprise')
   .action(cmd('enterprise'))
 enterprise
-  .command('create-user <name>')
+  .command('create-user <n>')
   .description('create user in enterprise')
   .option('-e, --email <email>', 'email to create user with')
   .action(cmd('enterprise'))
 enterprise
-  .command('create-app-user <name>')
+  .command('create-app-user <n>')
   .description('create app user in enterprise')
   .option('-o, --options <options>', 'options to create app user with')
   .action(cmd('enterprise'))
@@ -210,6 +210,36 @@ file
   .command('delete <fileId>')
   .description('delete file')
   .action(cmd('file'))
+
+const folders = program
+  .command('folders')
+  .description('folder commands')
+folders
+  .command('get <folderId>')
+  .description('get folder')
+  .action(cmd('folders'))
+folders
+  .command('get-items <folderId>')
+  .description('get items in folder')
+  .option('-l, --limit <limit>', 'limit number of items returned')
+  .option('-o, --offset <offset>', 'offset for pagination')
+  .action(cmd('folders'))
+folders
+  .command('create <name>')
+  .description('create folder')
+  .option('-p, --parent <parentId>', 'parent folder id')
+  .action(cmd('folders'))
+folders
+  .command('update <folderId>')
+  .description('update folder')
+  .option('-n, --name <name>', 'new name for folder')
+  .option('-d, --description <description>', 'new description for folder')
+  .action(cmd('folders'))
+folders
+  .command('delete <folderId>')
+  .description('delete folder')
+  .option('-r, --recursive', 'delete folder recursively')
+  .action(cmd('folders'))
 
 const groups = program
   .command('groups')
@@ -301,13 +331,13 @@ informationBarrierSegments
 informationBarrierSegments
   .command('create <barrierId>')
   .description('create information barrier segment')
-  .option('-n, --name <name>', 'name of information barrier segment')
+  .option('-n, --name <n>', 'name of information barrier segment')
   .option('-d, --description <description>', 'description of information barrier segment')
   .action(cmd('information-barrier-segments'))
 informationBarrierSegments
   .command('update <segmentId> <barrierId>')
   .description('update information barrier segment')
-  .option('-n, --name <name>', 'name of information barrier segment')
+  .option('-n, --name <n>', 'name of information barrier segment')
   .option('-d, --description <description>', 'description of information barrier segment')
   .action(cmd('information-barrier-segments'))
 informationBarrierSegments
@@ -430,7 +460,7 @@ signRequests
   .description('get sign request')
   .action(cmd('sign-requests'))
 signRequests
-  .command('create <name>')
+  .command('create <n>')
   .description('create sign request')
   .option('-p, --parentID <parentID>', 'parent id')
   .action(cmd('sign-requests'))
@@ -486,7 +516,7 @@ tasks
 tasks
   .command('update <taskID>')
   .description('update task')
-  .option('-n, --name <name>', 'name of task')
+  .option('-n, --name <n>', 'name of task')
   .option('-d, --description <description>', 'description of task')
   .action(cmd('tasks'))
 tasks
@@ -560,7 +590,7 @@ weblinks
   .description('get web link')
   .action(cmd('weblinks'))
 weblinks
-  .command('create <name>')
+  .command('create <n>')
   .description('create web link')
   .option('-p, --parentID <parentID>', 'parent folder id')
   .option('-u, --url <url>', 'url of web link')
@@ -569,7 +599,7 @@ weblinks
 weblinks
   .command('update <weblinkID>')
   .description('update web link')
-  .option('-n, --name <name>', 'name of web link')
+  .option('-n, --name <n>', 'name of web link')
   .option('-d, --description <description>', 'description of web link')
   .action(cmd('weblinks'))
 weblinks

--- a/src/folders.js
+++ b/src/folders.js
@@ -1,0 +1,50 @@
+const camelize = require('./lib/camelize')
+const client = require('./lib/client')
+const handleError = require('./lib/handle-error')
+const log = require('./lib/logger')
+
+const operations = {
+  get: async (folderId) => {
+    const folder = await client.folders.get(folderId)
+    log(folder)
+    return folder
+  },
+  getItems: async (folderId, options) => {
+    const items = await client.folders.getItems(folderId, options)
+    log(items)
+    return items
+  },
+  create: async (name, { parent }) => {
+    const folder = await client.folders.create(parent, name)
+    log(folder)
+    return folder
+  },
+  update: async (folderId, { name, description }) => {
+    const updates = {}
+    if (name) updates.name = name
+    if (description) updates.description = description
+    
+    const folder = await client.folders.update(folderId, updates)
+    log(folder)
+    return folder
+  },
+  delete: async (folderId, { recursive }) => {
+    await client.folders.delete(folderId, { recursive })
+    log('Folder deleted!')
+    return 'Folder deleted!'
+  }
+}
+
+async function folders (arg, options, subCommand) {
+  try {
+    const name = subCommand ? subCommand._name : options._name
+    const operation = operations[camelize(name)]
+    const result = await operation(arg, options)
+
+    return result
+  } catch (err) {
+    handleError(err)
+  }
+}
+
+module.exports = folders

--- a/test/folders.test.js
+++ b/test/folders.test.js
@@ -1,0 +1,42 @@
+const folders = require('../src/folders')
+
+let folderId
+
+test('can create a folder', async () => {
+  const folderName = `Test Folder ${Date.now()}`
+  const result = await folders(folderName, { parent: '0' }, { _name: 'create' })
+  
+  folderId = result.id
+  
+  expect(result.name).toBe(folderName)
+  expect(result.type).toBe('folder')
+})
+
+test('can get a folder', async () => {
+  const result = await folders(folderId, {}, { _name: 'get' })
+  
+  expect(result.id).toBe(folderId)
+  expect(result.type).toBe('folder')
+})
+
+test('can get items in a folder', async () => {
+  const result = await folders(folderId, { limit: 100 }, { _name: 'getItems' })
+  
+  expect(result).toHaveProperty('entries')
+  expect(result).toHaveProperty('total_count')
+  expect(Array.isArray(result.entries)).toBe(true)
+})
+
+test('can update a folder', async () => {
+  const newName = `Updated Folder ${Date.now()}`
+  const result = await folders(folderId, { name: newName }, { _name: 'update' })
+  
+  expect(result.name).toBe(newName)
+  expect(result.id).toBe(folderId)
+})
+
+test('can delete a folder', async () => {
+  const result = await folders(folderId, { recursive: true }, { _name: 'delete' })
+  
+  expect(result).toBe('Folder deleted!')
+})


### PR DESCRIPTION
This PR adds a new `folders` command to the Box CLI with the following operations:

- `get` - Get folder information
- `get-items` - List items in a folder
- `create` - Create a new folder
- `update` - Update folder properties
- `delete` - Delete a folder

Tests have been added to verify the functionality.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author