### PR TITLE
Add folders command with comprehensive functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,44 @@ file
   .description('delete file')
   .action(cmd('file'))
 
+const folders = program
+  .command('folders')
+  .description('folder commands')
+folders
+  .command('get <folderId>')
+  .description('get folder information')
+  .action(cmd('folders'))
+folders
+  .command('list-items <folderId>')
+  .description('list items in folder')
+  .option('-l, --limit <limit>', 'limit number of items returned')
+  .option('-o, --offset <offset>', 'offset for pagination')
+  .option('-f, --fields <fields>', 'comma-separated list of fields to return')
+  .action(cmd('folders'))
+folders
+  .command('create <name>')
+  .description('create folder')
+  .option('-p, --parent <parentId>', 'parent folder ID (default: root folder)')
+  .option('-d, --description <description>', 'folder description')
+  .action(cmd('folders'))
+folders
+  .command('update <folderId>')
+  .description('update folder')
+  .option('-n, --name <name>', 'new folder name')
+  .option('-d, --description <description>', 'new folder description')
+  .action(cmd('folders'))
+folders
+  .command('copy <folderId>')
+  .description('copy folder')
+  .option('-p, --parent <parentId>', 'destination parent folder ID (default: root folder)')
+  .option('-n, --name <name>', 'new folder name')
+  .action(cmd('folders'))
+folders
+  .command('delete <folderId>')
+  .description('delete folder')
+  .option('-r, --recursive <recursive>', 'delete folder and all contents (true/false)')
+  .action(cmd('folders'))
+
 const groups = program
   .command('groups')
   .description('groups commands')

--- a/src/folders.js
+++ b/src/folders.js
@@ -1,0 +1,71 @@
+const camelize = require('./lib/camelize')
+const client = require('./lib/client')
+const handleError = require('./lib/handle-error')
+const log = require('./lib/logger')
+
+const operations = {
+  get: async (folderId) => {
+    const folder = await client.folders.get(folderId)
+    log(folder)
+    return folder
+  },
+  listItems: async (folderId, { limit, offset, fields }) => {
+    const options = {}
+    if (limit) options.limit = parseInt(limit)
+    if (offset) options.offset = parseInt(offset)
+    if (fields) options.fields = fields
+    
+    const items = await client.folders.getItems(folderId, options)
+    log(items)
+    return items
+  },
+  create: async (name, { parent, description }) => {
+    const parentId = parent || '0' // Default to root folder
+    const options = {}
+    if (description) options.description = description
+    
+    const folder = await client.folders.create(parentId, name, options)
+    log(folder)
+    return folder
+  },
+  update: async (folderId, { name, description }) => {
+    const updates = {}
+    if (name) updates.name = name
+    if (description) updates.description = description
+    
+    const folder = await client.folders.update(folderId, updates)
+    log(folder)
+    return folder
+  },
+  copy: async (folderId, { parent, name }) => {
+    const parentId = parent || '0' // Default to root folder
+    const options = {}
+    if (name) options.name = name
+    
+    const folder = await client.folders.copy(folderId, parentId, options)
+    log(folder)
+    return folder
+  },
+  delete: async (folderId, { recursive }) => {
+    const options = {}
+    if (recursive === 'true') options.recursive = true
+    
+    await client.folders.delete(folderId, options)
+    log('Folder deleted!')
+    return 'Folder deleted!'
+  }
+}
+
+async function folders (arg, options, subCommand) {
+  try {
+    const name = subCommand ? subCommand._name : options._name
+    const operation = operations[camelize(name)]
+    const result = await operation(arg, options)
+
+    return result
+  } catch (err) {
+    handleError(err)
+  }
+}
+
+module.exports = folders

--- a/test/folders.test.js
+++ b/test/folders.test.js
@@ -1,0 +1,89 @@
+const folders = require('../src/folders')
+
+// Mock the client to avoid authentication issues in tests
+jest.mock('../src/lib/client', () => ({
+  folders: {
+    get: jest.fn(),
+    getItems: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    copy: jest.fn(),
+    delete: jest.fn()
+  }
+}))
+
+const mockClient = require('../src/lib/client')
+
+describe('Folders CLI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should call client.folders.get for get command', async () => {
+    const mockFolder = { id: '123', name: 'Test Folder', type: 'folder' }
+    mockClient.folders.get.mockResolvedValue(mockFolder)
+
+    const result = await folders('123', {}, { _name: 'get' })
+
+    expect(mockClient.folders.get).toHaveBeenCalledWith('123')
+    expect(result).toEqual(mockFolder)
+  })
+
+  test('should call client.folders.getItems for list-items command', async () => {
+    const mockItems = { entries: [], total_count: 0 }
+    mockClient.folders.getItems.mockResolvedValue(mockItems)
+
+    const result = await folders('123', { limit: '10', offset: '0' }, { _name: 'list-items' })
+
+    expect(mockClient.folders.getItems).toHaveBeenCalledWith('123', { limit: 10, offset: 0 })
+    expect(result).toEqual(mockItems)
+  })
+
+  test('should call client.folders.create for create command', async () => {
+    const mockFolder = { id: '456', name: 'New Folder', type: 'folder' }
+    mockClient.folders.create.mockResolvedValue(mockFolder)
+
+    const result = await folders('New Folder', { parent: '0', description: 'Test description' }, { _name: 'create' })
+
+    expect(mockClient.folders.create).toHaveBeenCalledWith('0', 'New Folder', { description: 'Test description' })
+    expect(result).toEqual(mockFolder)
+  })
+
+  test('should call client.folders.update for update command', async () => {
+    const mockFolder = { id: '123', name: 'Updated Folder', type: 'folder' }
+    mockClient.folders.update.mockResolvedValue(mockFolder)
+
+    const result = await folders('123', { name: 'Updated Folder', description: 'Updated description' }, { _name: 'update' })
+
+    expect(mockClient.folders.update).toHaveBeenCalledWith('123', { name: 'Updated Folder', description: 'Updated description' })
+    expect(result).toEqual(mockFolder)
+  })
+
+  test('should call client.folders.copy for copy command', async () => {
+    const mockFolder = { id: '789', name: 'Copied Folder', type: 'folder' }
+    mockClient.folders.copy.mockResolvedValue(mockFolder)
+
+    const result = await folders('123', { parent: '0', name: 'Copied Folder' }, { _name: 'copy' })
+
+    expect(mockClient.folders.copy).toHaveBeenCalledWith('123', '0', { name: 'Copied Folder' })
+    expect(result).toEqual(mockFolder)
+  })
+
+  test('should call client.folders.delete for delete command', async () => {
+    mockClient.folders.delete.mockResolvedValue()
+
+    const result = await folders('123', {}, { _name: 'delete' })
+
+    expect(mockClient.folders.delete).toHaveBeenCalledWith('123', {})
+    expect(result).toBe('Folder deleted!')
+  })
+
+  test('should handle recursive delete option', async () => {
+    mockClient.folders.delete.mockResolvedValue()
+
+    const result = await folders('123', { recursive: 'true' }, { _name: 'delete' })
+
+    expect(mockClient.folders.delete).toHaveBeenCalledWith('123', { recursive: true })
+    expect(result).toBe('Folder deleted!')
+  })
+})


### PR DESCRIPTION
## Summary

This PR adds a comprehensive `folders` command to the Box CLI with full CRUD functionality for managing folders.

## Features Added

### New Commands
- `box folders get <folderId>` - Get folder information
- `box folders list-items <folderId>` - List items in folder with pagination options
- `box folders create <name>` - Create new folder with optional description
- `box folders update <folderId>` - Update folder name and description
- `box folders copy <folderId>` - Copy folder to new location
- `box folders delete <folderId>` - Delete folder with optional recursive option

### Implementation Details
- **src/folders.js**: Core folder operations using Box SDK
- **index.js**: Command definitions with proper options and help text
- **test/folders.test.js**: Comprehensive test suite with mocked client

### Command Examples
```bash
# Get folder information
box folders get 12345

# List items in folder with pagination
box folders list-items 12345 --limit 10 --offset 0

# Create a new folder
box folders create "My New Folder" --parent 0 --description "A test folder"

# Update folder
box folders update 12345 --name "Updated Name" --description "New description"

# Copy folder
box folders copy 12345 --parent 0 --name "Copied Folder"

# Delete folder (with recursive option)
box folders delete 12345 --recursive true
```

## Testing
- ✅ All tests passing (7/7)
- ✅ CLI commands properly structured with help text
- ✅ Error handling implemented
- ✅ Follows existing code patterns and conventions

## Validation
- Commands follow the same pattern as existing commands (file, comments, etc.)
- Uses the same error handling and logging utilities
- Comprehensive test coverage with mocked Box SDK client
- All CLI help text and options properly configured

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author